### PR TITLE
去掉多余的命令行脚本

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -7,6 +7,5 @@ return [
     'commands' => [
         \think\annotation\command\make\Annotation::class,
         \think\annotation\command\make\Handler::class,
-        \think\annotation\command\make\Doc::class
     ],
 ];


### PR DESCRIPTION
#13 

更新内容：

- 去掉多余的命令行脚本`\think\annotation\command\make\Doc::class`